### PR TITLE
Fix clang warnings: class vs struct.

### DIFF
--- a/include/FeatureFactory.h
+++ b/include/FeatureFactory.h
@@ -12,7 +12,7 @@
 using namespace std;
 
 class Engine;
-class FeatureData;
+struct FeatureData;
 
 enum FeatureSpawnData_t {
   featureSpawnData_dynamite,

--- a/include/Knockback.h
+++ b/include/Knockback.h
@@ -5,7 +5,7 @@
 
 class Engine;
 class Actor;
-struct AttackData;
+class AttackData;
 
 class KnockBack {
 public:

--- a/include/RoomTheme.h
+++ b/include/RoomTheme.h
@@ -9,7 +9,7 @@
 using namespace std;
 
 class Engine;
-class FeatureData;
+struct FeatureData;
 
 enum RoomTheme_t {
   roomTheme_plain,


### PR DESCRIPTION
This is very simple change, but removes a lot of noise emitted by clang (all struct vs class warnings).
