### PR TITLE
Spellchecking fixes.

### DIFF
--- a/include/Actor.h
+++ b/include/Actor.h
@@ -59,7 +59,7 @@ public:
   virtual void updateColor();
 
   //Function taking into account FOV, invisibility, status, etc
-  //This is the final word on wether an actor can visually percieve
+  //This is the final word on whether an actor can visually perceive
   //another actor.
   bool checkIfSeeActor(
     const Actor& other,

--- a/include/ItemPotion.h
+++ b/include/ItemPotion.h
@@ -242,7 +242,7 @@ public:
     potionLooks_.push_back(PotionLook {"Smoky",    "a Smoky",    clrWhite});
     potionLooks_.push_back(PotionLook {"Slimy",    "a Slimy",    clrGreen});
     potionLooks_.push_back(PotionLook {"Green",    "a Green",    clrGreenLgt});
-    potionLooks_.push_back(PotionLook {"Fiery",    "a Firey",    clrRedLgt});
+    potionLooks_.push_back(PotionLook {"Fiery",    "a Fiery",    clrRedLgt});
     potionLooks_.push_back(PotionLook {"Murky",    "a Murky",    clrBrownDrk});
     potionLooks_.push_back(PotionLook {"Muddy",    "a Muddy",    clrBrown});
     potionLooks_.push_back(PotionLook {"Violet",   "a Violet",   clrViolet});

--- a/src/ActorData.cpp
+++ b/src/ActorData.cpp
@@ -322,7 +322,7 @@ void ActorDataHandler::initDataList() {
   d.canBashDoors = true;
   d.nrTurnsAwarePlayer = 25;
   d.description = "A fanatic cultist of the lowest rank, madly gibbering in some half-lost language.";
-  d.spellCastMessage = "The accolyte makes strange gestures in the air.";
+  d.spellCastMessage = "The acolyte makes strange gestures in the air.";
   d.erraticMovement = actorErratic_rare;
   d.nativeRooms.push_back(roomTheme_plain);
   d.nativeRooms.push_back(roomTheme_human);
@@ -359,7 +359,7 @@ void ActorDataHandler::initDataList() {
   d.canBashDoors = true;
   d.nrTurnsAwarePlayer = 25;
   d.description = "A fanatic cultist of the lowest rank, madly gibbering in some half-lost language. It is wielding a Tesla Cannon.";
-  d.spellCastMessage = "The accolyte makes strange gestures in the air.";
+  d.spellCastMessage = "The acolyte makes strange gestures in the air.";
   d.erraticMovement = actorErratic_rare;
   d.nativeRooms.push_back(roomTheme_plain);
   d.nativeRooms.push_back(roomTheme_human);
@@ -396,7 +396,7 @@ void ActorDataHandler::initDataList() {
   d.canBashDoors = true;
   d.nrTurnsAwarePlayer = 25;
   d.description = "A fanatic cultist of the lowest rank, madly gibbering in some half-lost language. It is wielding a Spike gun.";
-  d.spellCastMessage = "The accolyte makes strange gestures in the air.";
+  d.spellCastMessage = "The acolyte makes strange gestures in the air.";
   d.erraticMovement = actorErratic_rare;
   d.nativeRooms.push_back(roomTheme_plain);
   d.nativeRooms.push_back(roomTheme_human);
@@ -430,7 +430,7 @@ void ActorDataHandler::initDataList() {
   d.groupSize = monsterGroupSize_alone;
   d.actorSize = actorSize_humanoid;
   d.isHumanoid = true;
-  d.description = "During the Salem witch trials of 1692 an old woman by the name of Keziah Mason was arrested for her suspicious behavior and seeming insight into other worlds. In her testimony to the judge, she confessed to having signed her name in the Black Book of Azathoth, and of her secret name of Nahab. She later disappeared mysteriously from Salem. She is described as having a \"bent back, long nose, and shrivelled chin\" and has a \"croaking voice\". She has an animal familier; the rat Brown Jenkin, which she trusts to carry messages between her and the devil. She feeds this creature on her blood.";
+  d.description = "During the Salem witch trials of 1692 an old woman by the name of Keziah Mason was arrested for her suspicious behavior and seeming insight into other worlds. In her testimony to the judge, she confessed to having signed her name in the Black Book of Azathoth, and of her secret name of Nahab. She later disappeared mysteriously from Salem. She is described as having a \"bent back, long nose, and shrivelled chin\" and has a \"croaking voice\". She has an animal familiar; the rat Brown Jenkin, which she trusts to carry messages between her and the devil. She feeds this creature on her blood.";
   d.spellCastMessage = "Keziah makes strange gestures in the air.";
   d.aggroTextMonsterSeen = d.name_the + " chortles at me in a croaking voice.";
   d.aggroTextMonsterHidden = "I hear a repulsive croaking voice.";
@@ -1228,7 +1228,7 @@ void ActorDataHandler::initDataList() {
   d.canBashDoors = true;
   d.canOpenDoors = true;
   d.nrTurnsAwarePlayer = 25;
-  d.description = "Fungi are more closely related to animals than plants, so it's no wonder that on some worlds, fungal life evolved to dominate animal based intelligences. The mi-go, as they are called, come from such a world. More like crustaceans than any other terrestial life form, they find themselves somewhat hampered by our planet's thicker atmosphere and heavy gravity. They are a highly scientific race with great aptitude for surgery. Typical mi-go have heads like large exposed brains, with many convolutions on the wrinkled surfaces; six to eight limbs, a single pair of vast membranous wings, and a long semiprehensile tail trailing beind. They have visited Earth for centuries to mine certain minerals not available on their icy world, and more recently, to study its odd inhabitants. The mi-go are responsible for many \"alien abduction\" kidnappings. Physically they are not much more robust than the average human, they rely upon their superior science to subdue any primitives who stumble upon their mines and outposts.";
+  d.description = "Fungi are more closely related to animals than plants, so it's no wonder that on some worlds, fungal life evolved to dominate animal based intelligences. The mi-go, as they are called, come from such a world. More like crustaceans than any other terrestrial life form, they find themselves somewhat hampered by our planet's thicker atmosphere and heavy gravity. They are a highly scientific race with great aptitude for surgery. Typical mi-go have heads like large exposed brains, with many convolutions on the wrinkled surfaces; six to eight limbs, a single pair of vast membranous wings, and a long semiprehensile tail trailing beind. They have visited Earth for centuries to mine certain minerals not available on their icy world, and more recently, to study its odd inhabitants. The mi-go are responsible for many \"alien abduction\" kidnappings. Physically they are not much more robust than the average human, they rely upon their superior science to subdue any primitives who stumble upon their mines and outposts.";
   d.spellCastMessage = "The Fungi makes strange gestures in the air.";
   d.aggroTextMonsterSeen = d.name_the + " speaks at me in a droning voice.";
   d.aggroTextMonsterHidden = "I hear a droning voice.";
@@ -1393,7 +1393,7 @@ void ActorDataHandler::initDataList() {
   d.canBashDoors = true;
   d.canOpenDoors = true;
   d.nrTurnsAwarePlayer = 9999;
-  d.description = "A mummified human being, possibly dating back millenia.";
+  d.description = "A mummified human being, possibly dating back millennia.";
   d.spellCastMessage = "The mummy casts a spell.";
   d.erraticMovement = actorErratic_rare;
   d.monsterShockLevel = monsterShockLevel_scary;

--- a/src/ActorMonsterSpecific.cpp
+++ b/src/ActorMonsterSpecific.cpp
@@ -493,7 +493,7 @@ bool KeziahMason::onActorTurn_() {
           for(int i = 0; i < LINE_SIZE; i++) {
             const Pos c = line.at(i);
             if(blockers[c.x][c.y] == false) {
-              //TODO Make a generalized summoning funtionality
+              //TODO Make a generalized summoning functionality
               eng.log->addMsg("Keziah summons Brown Jenkin!");
               Actor* const actor =
                 eng.actorFactory->spawnActor(actor_brownJenkin, c);

--- a/src/AttackRanged.cpp
+++ b/src/AttackRanged.cpp
@@ -180,7 +180,7 @@ void Attack::projectileFire(Actor& attacker, Weapon& wpn, const Pos& aimPos) {
                                   curProj->attackData->dmg,
                                   wpn.getData().rangedDmgType, true);
               if(DIED == false) {
-                // Aply weapon hit properties
+                // Apply weapon hit properties
                 PropHandler& defenderPropHandler =
                   curProj->attackData->curDefender->getPropHandler();
                 defenderPropHandler.tryApplyPropFromWpn(wpn, false);

--- a/src/Bot.cpp
+++ b/src/Bot.cpp
@@ -48,7 +48,7 @@ void Bot::act() {
     eng.player->teleport(false);
   }
 
-  //Ocassionally send a TAB command to attack nearby monsters
+  //Occasionally send a TAB command to attack nearby monsters
   if(eng.dice.coinToss()) {
     eng.input->handleKeyPress(KeyboardReadReturnData(SDLK_TAB));
     return;

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -184,7 +184,7 @@ void FeatureStatic::bash(Actor& actorTrying) {
 
 void FeatureStatic::bash_(Actor& actorTrying) {
   //Emitting the sound from the actor instead of the bashed object, because the
-  //sound mesage should be received even if the object is seen
+  //sound massage should be received even if the object is seen
   const AlertsMonsters alertsMonsters = &actorTrying == eng.player ?
                                         AlertsMonsters::yes :
                                         AlertsMonsters::no;

--- a/src/FeatureExaminable.cpp
+++ b/src/FeatureExaminable.cpp
@@ -320,7 +320,7 @@ void Tomb::examine() {
 //    if(IS_CURSED == false && (IS_BLESSED || eng.dice.fraction(4, 5))) {
 //      eng.log->addMsg("The curse is cleared.");
 //    } else {
-//      eng.log->addMsg("I make a misstake, the curse is doubled!");
+//      eng.log->addMsg("I make a mistake, the curse is doubled!");
 //      PropCursed* const curse =
 //        new PropCursed(eng, propTurnsStd);
 //      curse->turnsLeft_ *= 2;

--- a/src/FeatureTrap.cpp
+++ b/src/FeatureTrap.cpp
@@ -647,7 +647,7 @@ void TrapSummonMonster::trigger(
     }
   }
 
-  trace << "TrapSummonMonster: Finding summon canidates" << endl;
+  trace << "TrapSummonMonster: Finding summon candidates" << endl;
   vector<ActorId> summonCandidates;
   for(int i = 1; i < endOfActorIds; i++) {
     const ActorData& data = eng.actorDataHandler->dataList[i];

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -532,11 +532,11 @@ bool Inventory::hasItemInSlot(SlotId slotName) const {
 }
 
 void Inventory::removeItemInElementWithoutDeletingInstance(const int GLOBAL_ELEMENT) {
-  //If parameter element corresponds to equiped slots, remove item in that slot
+  //If parameter element corresponds to equipped slots, remove item in that slot
   if(GLOBAL_ELEMENT >= 0 && GLOBAL_ELEMENT < signed(slots_.size())) {
     slots_.at(GLOBAL_ELEMENT).item = NULL;
   } else {
-    //If paramater element corresponds to general slot, remove that slot
+    //If parameter element corresponds to general slot, remove that slot
     const int GENERAL_ELEMENT = GLOBAL_ELEMENT - slots_.size();
     if(GENERAL_ELEMENT >= 0 && GENERAL_ELEMENT < signed(general_.size())) {
       general_.erase(general_.begin() + GENERAL_ELEMENT);

--- a/src/ItemDevice.cpp
+++ b/src/ItemDevice.cpp
@@ -52,7 +52,7 @@ void Device::printToggleMessage() {
   const string name_a =
     eng.itemDataHandler->getItemRef(*this, itemRef_a, true);
   eng.log->addMsg(
-    (isActivated_ ? "I deactive " : "I activate ") + name_a + ".");
+    (isActivated_ ? "I deactivate " : "I activate ") + name_a + ".");
 }
 
 int Device::getRandomNrTurnsToNextGoodEffect() const {

--- a/src/MapGenBsp.cpp
+++ b/src/MapGenBsp.cpp
@@ -726,7 +726,7 @@ void MapGenBsp::getAllowedStairCells(bool cellsToSet[MAP_W][MAP_H]) const {
   trace << "MapGenBsp::getAllowedStairCells()..." << endl;
 
   //Stairs are only allowed in cells with - and completely surrounded by -
-  //stone flooor or cave floor
+  //stone floor or cave floor
 
   vector<FeatureId> featIdsOk {feature_stoneFloor, feature_caveFloor};
 

--- a/src/PlayerBonuses.cpp
+++ b/src/PlayerBonuses.cpp
@@ -584,7 +584,7 @@ void PlayerBonHandler::pickBg(const Bg bg) {
 
       eng.player->changeMaxHp(-2, false);
 
-      //Player starts with a scroll of Darkbolt, and one other random srcoll
+      //Player starts with a scroll of Darkbolt, and one other random scroll
       //Both are identified
       Item* scroll = eng.itemFactory->spawnItem(item_scrollOfDarkbolt);
       dynamic_cast<Scroll*>(scroll)->identify(true);

--- a/src/Properties.cpp
+++ b/src/Properties.cpp
@@ -875,7 +875,7 @@ void PropHandler::tryApplyProp(Prop* const prop, const bool FORCE_EFFECT,
   //-If it doesn't, then just add it to the buffer and return.
   //-If the buffer already contains the prop, it means it was requested to be
   //applied from the buffer to the applied props.
-  //This way, this function can be used both for requesting to appply props,
+  //This way, this function can be used both for requesting to apply props,
   //and for applying props from the buffer.
   if(prop->getTurnMode() == propTurnModeActor) {
     vector<Prop*>& buffer = actorTurnPropBuffer_;
@@ -918,7 +918,7 @@ void PropHandler::tryApplyProp(Prop* const prop, const bool FORCE_EFFECT,
 
   //This point reached means nothing is blocking the property.
 
-  //Actor already has property appplied?
+  //Actor already has property applied?
   for(Prop * oldProp : appliedProps_) {
     if(prop->getId() == oldProp->getId()) {
 

--- a/src/Spells.cpp
+++ b/src/Spells.cpp
@@ -708,7 +708,7 @@ SpellCastRetData SpellTeleport::cast_(
   if(caster != eng.player) {
     if(eng.player->checkIfSeeActor(*caster, NULL)) {
       eng.log->addMsg(
-        caster->getNameThe() + " dissapears in a blast of smoke!");
+        caster->getNameThe() + " disappears in a blast of smoke!");
     }
   }
 


### PR DESCRIPTION
Used **aspell** and very simple shell script (aspell accepts only one file at the time):

``` sh
for file in src/*.cpp; do aspell check --master=en_US --add-extra-dicts=en_GB --mode=ccpp $file; done
```

Used both British and American dictionaries as spelling is mixed. 
