### PR TITLE
Use predefined __DATE__ macro for better version identyfication.

### DIFF
--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -166,7 +166,7 @@ void MainMenu::draw(const MenuBrowser& browser) const {
                              panel_screen);
 
   Renderer::drawTextCentered(
-    gameVersionStr + " 2013-11-26 (c) 2011-2014 Martin Tornqvist",
+    gameVersionStr + " - " + __DATE__ + " (c) 2011-2014 Martin Tornqvist",
     panel_screen, Pos(MAP_W_HALF, SCREEN_H - 1), clrWhite);
 
   Renderer::updateScreen();


### PR DESCRIPTION
Via GCC docs: http://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html

> This macro expands to a string constant that describes the date on which the preprocessor is being run. The string constant contains eleven characters and looks like "Feb 12 1996". If the day of the month is less than 10, it is padded with a space on the left.

So date displayed in main menu is updated, every time when you recompile file.
