### PR TITLE
Changed 'manual' to 'tome of wisdom' in in-game menu

### DIFF
--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -878,7 +878,7 @@ void handleMapModeKeyPress(const KeyData& d)
     {
       Log::clearLog();
 
-      const vector<string> choices {"Options", "Manual", "Quit", "Cancel"};
+      const vector<string> choices {"Options", "Tome of Wisdom", "Quit", "Cancel"};
       const int CHOICE = Popup::showMenuMsg("", true, choices);
 
       if (CHOICE == 0)


### PR DESCRIPTION
The option to view the manual is named "Tome of Wisdom" in the mainmenu, but the in-game menu entry is still named "Manual"

This PR fixes the inconsistence mentioned above.
