### PR TITLE
fixed game crashing error in reload.cpp

### DIFF
--- a/src/reload.cpp
+++ b/src/reload.cpp
@@ -303,7 +303,7 @@ void player_arrange_pistol_mags()
             wpn->nr_ammo_loaded_ < PISTOL_MAX_AMMO)
         {
             --min_mag->ammo_;
-            ++wielded_pistol->nr_ammo_loaded_;
+            ++wpn->nr_ammo_loaded_;
 
             if (min_mag->ammo_ == 0)
             {


### PR DESCRIPTION
When you use the 'R' command a game crash can occur under certain circumstances do to what I assume is a typo in reload.cpp. This fixes the typo. I found the location of the typo using the debugger.