### PR TITLE
fixes #81

### DIFF
--- a/src/knockback.cpp
+++ b/src/knockback.cpp
@@ -81,9 +81,9 @@ void try_knock_back(Actor&        defender,
 
             if (i == 0)
             {
-                if (IS_MSG_ALLOWED)
+                if (IS_MSG_ALLOWED && IS_PLAYER_SEE_DEF)
                 {
-                    if (IS_DEF_MON && IS_PLAYER_SEE_DEF)
+                    if (IS_DEF_MON)
                     {
                         msg_log::add(defender.name_the() + " is knocked back!");
                     }

--- a/src/knockback.cpp
+++ b/src/knockback.cpp
@@ -104,9 +104,9 @@ void try_knock_back(Actor&        defender,
                 sdl_wrapper::sleep(config::delay_projectile_draw());
             }
 
-            if (IS_CELL_BOTTOMLESS && !defender.has_prop(Prop_id::flying))
+            if (IS_CELL_BOTTOMLESS && !defender.has_prop(Prop_id::flying) && IS_PLAYER_SEE_DEF)
             {
-                if (IS_DEF_MON && IS_PLAYER_SEE_DEF)
+                if (IS_DEF_MON)
                 {
                     msg_log::add(defender.name_the() + " plummets down the depths.",
                                  clr_msg_good);


### PR DESCRIPTION
fixes #81 
In the original, not being able to see a monster caused it to go to the else which assumed the one being knocked out is the player.