### PR TITLE
Convenience changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# bin/ is the same as build/
+bin/
 build/
 target/
 obj/

--- a/src/create_character.cpp
+++ b/src/create_character.cpp
@@ -109,6 +109,12 @@ void PickBgState::on_start()
     browser_.set_y((int)Bg::rogue);
 }
 
+void pop_states(const int number)
+{
+  for ( int i = 0; i < number; i++ )
+    states::pop();
+}
+
 void PickBgState::update()
 {
     if (config::is_bot_playing())
@@ -136,6 +142,12 @@ void PickBgState::update()
         player_bon::pick_bg(bg);
 
         states::pop();
+    }
+    break;
+
+    case MenuAction::esc:
+    {
+      pop_states(4);
     }
     break;
 
@@ -277,6 +289,12 @@ void PickTraitState::update()
 
     switch (action)
     {
+    case MenuAction::esc:
+    {
+      pop_states(3);
+    }
+    break;
+
     case MenuAction::selected:
     case MenuAction::selected_shift:
     {
@@ -546,6 +564,12 @@ void EnterNameState::update()
     }
 
     const auto input = io::get(false);
+
+    if (input.key == SDLK_ESCAPE)
+    {
+      pop_states(2);
+      return;
+    }
 
     if (input.key == SDLK_RETURN)
     {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -59,8 +59,8 @@ void query_quit()
 {
     const auto quit_choices = std::vector<std::string>
     {
-        "yes",
-        "no"
+        "Yes",
+        "No"
     };
 
     const int quit_choice =

--- a/src/postmortem.cpp
+++ b/src/postmortem.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <string>
 
+#include "audio.hpp"
 #include "init.hpp"
 #include "io.hpp"
 #include "actor_player.hpp"
@@ -403,6 +404,8 @@ void PostmortemMenu::update()
             std::unique_ptr<State> new_game_state(new NewGameState);
 
             states::push(std::move(new_game_state));
+
+            audio::fade_out_music();
 
             return;
         }


### PR DESCRIPTION
All the commit messages should be explanatory enough:

1. Added bin/ to .gitignore, just because I used bin/ instead of build/ ( same thing)
    Also, added fade_out_music() when going for a new game at the postmortem screen, so Musica Cthulhiana - Madness didn't overlap with the actual game.
2. Changed case from lower to upper in the popup window for 'yes' and 'no'.
3. Made it so that when you press ESC in the character creation set of screens, in the background, trait and name ones, you go back to the main menu. Pressing ESC in the "Initial Story" window works like before - it closes it so you can start to actually play.