### PR TITLE
IDs for all State children and working ESC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# bin/ is the same as build/
+bin/
 build/
 target/
 obj/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ CppCheckResults.xml
 *.depend
 *.pyc
 
+# Vim temporary files
+*.swp
+
 # Emacs gtags
 GPATH
 GRTAGS

--- a/include/character_descr.hpp
+++ b/include/character_descr.hpp
@@ -17,6 +17,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     std::vector<StrAndClr> lines_;
 

--- a/include/character_descr.hpp
+++ b/include/character_descr.hpp
@@ -17,7 +17,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     std::vector<StrAndClr> lines_;

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -53,7 +53,7 @@ public:
 
     void draw() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     MenuBrowser browser_;

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -53,6 +53,8 @@ public:
 
     void draw() override;
 
+    states::StateId id() override;
+
 private:
     MenuBrowser browser_;
 };

--- a/include/create_character.hpp
+++ b/include/create_character.hpp
@@ -14,25 +14,29 @@ enum class TraitScreenMode
 class NewGameState: public State
 {
 public:
-    NewGameState() {}
+    NewGameState();
 
-    ~NewGameState() {}
+    ~NewGameState();
 
     void on_pushed() override;
 
     void on_resume() override;
+
+    states::StateId id() override; 
 };
 
 class GainLvlState: public State
 {
 public:
-    GainLvlState() {}
+    GainLvlState();
 
-    ~GainLvlState() {}
+    ~GainLvlState();
 
     void on_start() override;
 
     void update() override;
+
+    states::StateId id() override;
 };
 
 class PickBgState: public State
@@ -40,13 +44,15 @@ class PickBgState: public State
 public:
     PickBgState();
 
-    ~PickBgState() {}
+    ~PickBgState();
 
     void on_start() override;
 
     void update() override;
 
     void draw() override;
+
+    states::StateId id() override;
 
 private:
     MenuBrowser browser_;
@@ -59,13 +65,15 @@ class PickTraitState: public State
 public:
     PickTraitState();
 
-    ~PickTraitState() {}
+    ~PickTraitState();
 
     void on_start() override;
 
     void update() override;
 
     void draw() override;
+
+    states::StateId id() override;
 
 private:
     MenuBrowser browser_traits_avail_;
@@ -82,13 +90,15 @@ class EnterNameState: public State
 public:
     EnterNameState();
 
-    ~EnterNameState() {}
+    ~EnterNameState();
 
     void on_start() override;
 
     void update() override;
 
     void draw() override;
+
+    states::StateId id() override;
 
 private:
     std::string current_str_;

--- a/include/create_character.hpp
+++ b/include/create_character.hpp
@@ -22,7 +22,7 @@ public:
 
     void on_resume() override;
 
-    states::StateId id() override; 
+    StateId id() override; 
 };
 
 class GainLvlState: public State
@@ -36,7 +36,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 };
 
 class PickBgState: public State
@@ -52,7 +52,7 @@ public:
 
     void draw() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     MenuBrowser browser_;
@@ -73,7 +73,7 @@ public:
 
     void draw() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     MenuBrowser browser_traits_avail_;
@@ -98,7 +98,7 @@ public:
 
     void draw() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     std::string current_str_;

--- a/include/game.hpp
+++ b/include/game.hpp
@@ -102,6 +102,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     void query_quit();
 

--- a/include/game.hpp
+++ b/include/game.hpp
@@ -102,7 +102,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     void query_quit();

--- a/include/highscore.hpp
+++ b/include/highscore.hpp
@@ -104,7 +104,7 @@ public:
         return entries_.empty();
     }
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     std::vector<HighscoreEntry> entries_;

--- a/include/highscore.hpp
+++ b/include/highscore.hpp
@@ -19,7 +19,7 @@ public:
                    bool is_win_game,
                    Bg player_bg);
 
-    ~HighscoreEntry() {}
+    ~HighscoreEntry();
 
     int score() const;
 
@@ -103,6 +103,8 @@ public:
         // If there are no entries, we draw an overlayed popup
         return entries_.empty();
     }
+
+    states::StateId id() override;
 
 private:
     std::vector<HighscoreEntry> entries_;

--- a/include/inventory_handling.hpp
+++ b/include/inventory_handling.hpp
@@ -20,6 +20,8 @@ public:
 
     virtual ~InvState() {}
 
+    states::StateId id() override;
+
 protected:
     void draw_slot(const SlotId id,
                    const int y,

--- a/include/inventory_handling.hpp
+++ b/include/inventory_handling.hpp
@@ -20,7 +20,7 @@ public:
 
     virtual ~InvState() {}
 
-    states::StateId id() override;
+    StateId id() override;
 
 protected:
     void draw_slot(const SlotId id,

--- a/include/look.hpp
+++ b/include/look.hpp
@@ -38,6 +38,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     void put_text(const std::string str,
                   const P& p,

--- a/include/look.hpp
+++ b/include/look.hpp
@@ -38,7 +38,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     void put_text(const std::string str,

--- a/include/main_menu.hpp
+++ b/include/main_menu.hpp
@@ -19,6 +19,8 @@ public:
 
     void on_resume() override;
 
+    states::StateId id() override;
+
 private:
     MenuBrowser browser_;
 };

--- a/include/main_menu.hpp
+++ b/include/main_menu.hpp
@@ -19,7 +19,7 @@ public:
 
     void on_resume() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     MenuBrowser browser_;

--- a/include/manual.hpp
+++ b/include/manual.hpp
@@ -21,7 +21,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     void read_file();

--- a/include/manual.hpp
+++ b/include/manual.hpp
@@ -21,6 +21,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     void read_file();
 

--- a/include/marker.hpp
+++ b/include/marker.hpp
@@ -36,7 +36,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 protected:
     virtual void on_start_hook() {}

--- a/include/marker.hpp
+++ b/include/marker.hpp
@@ -36,6 +36,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 protected:
     virtual void on_start_hook() {}
 

--- a/include/msg_log.hpp
+++ b/include/msg_log.hpp
@@ -100,6 +100,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     int top_line_nr_;
     int btm_line_nr_;

--- a/include/msg_log.hpp
+++ b/include/msg_log.hpp
@@ -100,7 +100,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     int top_line_nr_;

--- a/include/player_spells.hpp
+++ b/include/player_spells.hpp
@@ -61,7 +61,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     MenuBrowser browser_;

--- a/include/player_spells.hpp
+++ b/include/player_spells.hpp
@@ -61,6 +61,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     MenuBrowser browser_;
 

--- a/include/postmortem.hpp
+++ b/include/postmortem.hpp
@@ -18,7 +18,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     void mk_memorial_file() const;
@@ -38,7 +38,7 @@ public:
 
     void update() override;
 
-    states::StateId id() override;
+    StateId id() override;
 
 private:
     const int max_nr_lines_on_scr_;

--- a/include/postmortem.hpp
+++ b/include/postmortem.hpp
@@ -18,6 +18,8 @@ public:
 
     void update() override;
 
+    states::StateId id() override;
+
 private:
     void mk_memorial_file() const;
 
@@ -35,6 +37,8 @@ public:
     void draw() override;
 
     void update() override;
+
+    states::StateId id() override;
 
 private:
     const int max_nr_lines_on_scr_;

--- a/include/state.hpp
+++ b/include/state.hpp
@@ -4,6 +4,34 @@
 #include <vector>
 #include <memory>
 
+namespace states 
+{
+
+enum class StateId 
+{
+    DEFAULT_STATE,
+    MENU_STATE,
+    GAME_STATE,
+    BACKGROUND_STATE,
+    TRAIT_STATE,
+    NAME_STATE,
+    NEWGAME_STATE,
+    NEWLEVEL_STATE,
+    POSTMENU_STATE,
+    POSTINFO_STATE,
+    BROWSESPELLS_STATE,
+    MESSAGE_STATE,
+    MARKER_STATE,
+    MANUAL_STATE,
+    VIEWACTOR_STATE,
+    INV_STATE,
+    HIGHSCORE_STATE,
+    CONFIG_STATE,
+    DESCRIPT_STATE
+};
+
+} // states
+
 class State
 {
 public:
@@ -59,6 +87,11 @@ public:
         return has_started_;
     }
 
+    virtual states::StateId id()
+    {
+        return states::StateId::DEFAULT_STATE;
+    }
+
 private:
     bool has_started_;
 };
@@ -85,6 +118,10 @@ void pop_all();
 bool is_empty();
 
 bool is_current_state(const State& state);
+
+void pop_until(const states::StateId);
+
+bool contains_state(const states::StateId);
 
 } // states
 

--- a/include/state.hpp
+++ b/include/state.hpp
@@ -4,33 +4,27 @@
 #include <vector>
 #include <memory>
 
-namespace states 
-{
-
 enum class StateId 
 {
-    DEFAULT_STATE,
-    MENU_STATE,
-    GAME_STATE,
-    BACKGROUND_STATE,
-    TRAIT_STATE,
-    NAME_STATE,
-    NEWGAME_STATE,
-    NEWLEVEL_STATE,
-    POSTMENU_STATE,
-    POSTINFO_STATE,
-    BROWSESPELLS_STATE,
-    MESSAGE_STATE,
-    MARKER_STATE,
-    MANUAL_STATE,
-    VIEWACTOR_STATE,
-    INV_STATE,
-    HIGHSCORE_STATE,
-    CONFIG_STATE,
-    DESCRIPT_STATE
+    menu,
+    game,
+    pick_background,
+    pick_trait,
+    pick_name,
+    new_game,
+    new_level,
+    postmortem_menu,
+    postmortem_info,
+    browse_spells,
+    message,
+    marker,
+    manual,
+    view_actor,
+    inventory,
+    highscore,
+    config,
+    descript 
 };
-
-} // states
 
 class State
 {
@@ -87,10 +81,7 @@ public:
         return has_started_;
     }
 
-    virtual states::StateId id()
-    {
-        return states::StateId::DEFAULT_STATE;
-    }
+    virtual StateId id() = 0;
 
 private:
     bool has_started_;
@@ -119,9 +110,9 @@ bool is_empty();
 
 bool is_current_state(const State& state);
 
-void pop_until(const states::StateId);
+void pop_until(const StateId);
 
-bool contains_state(const states::StateId);
+bool contains_state(const StateId);
 
 } // states
 

--- a/src/character_descr.cpp
+++ b/src/character_descr.cpp
@@ -20,9 +20,9 @@ const int max_nr_lines_on_scr = screen_h - 2;
 
 } // namespace
 
-states::StateId CharacterDescr::id()
+StateId CharacterDescr::id()
 {
-    return states::StateId::DESCRIPT_STATE;
+    return StateId::descript;
 }
 
 void CharacterDescr::on_start()

--- a/src/character_descr.cpp
+++ b/src/character_descr.cpp
@@ -20,6 +20,11 @@ const int max_nr_lines_on_scr = screen_h - 2;
 
 } // namespace
 
+states::StateId CharacterDescr::id()
+{
+    return states::StateId::DESCRIPT_STATE;
+}
+
 void CharacterDescr::on_start()
 {
     lines_.clear();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -707,9 +707,9 @@ ConfigState::ConfigState() :
 
 }
 
-states::StateId ConfigState::id()
+StateId ConfigState::id()
 {
-    return states::StateId::CONFIG_STATE;
+    return StateId::config;
 }
 
 void ConfigState::update()

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -707,6 +707,11 @@ ConfigState::ConfigState() :
 
 }
 
+states::StateId ConfigState::id()
+{
+    return states::StateId::CONFIG_STATE;
+}
+
 void ConfigState::update()
 {
     const auto input = io::get(true);

--- a/src/create_character.cpp
+++ b/src/create_character.cpp
@@ -109,6 +109,12 @@ void PickBgState::on_start()
     browser_.set_y((int)Bg::rogue);
 }
 
+void pop_states(const int number)
+{
+  for ( int i = 0; i < number; i++ )
+    states::pop();
+}
+
 void PickBgState::update()
 {
     if (config::is_bot_playing())
@@ -136,6 +142,12 @@ void PickBgState::update()
         player_bon::pick_bg(bg);
 
         states::pop();
+    }
+    break;
+
+    case MenuAction::esc:
+    {
+      pop_states(4);
     }
     break;
 
@@ -277,6 +289,12 @@ void PickTraitState::update()
 
     switch (action)
     {
+    case MenuAction::esc:
+    {
+      pop_states(3);
+    }
+    break;
+
     case MenuAction::selected:
     case MenuAction::selected_shift:
     {
@@ -546,6 +564,12 @@ void EnterNameState::update()
     }
 
     const auto input = io::get(false);
+
+    if (input.key == SDLK_ESCAPE)
+    {
+      pop_states(2);
+      return;
+    }
 
     if (input.key == SDLK_RETURN)
     {

--- a/src/create_character.cpp
+++ b/src/create_character.cpp
@@ -34,6 +34,21 @@ const int descr_w_ = descr_x1_ - descr_y1_ + 1;
 // -----------------------------------------------------------------------------
 // New game state
 // -----------------------------------------------------------------------------
+NewGameState::NewGameState()
+{
+
+}
+
+NewGameState::~NewGameState()
+{
+
+}
+
+states::StateId NewGameState::id()
+{
+    return states::StateId::NEWGAME_STATE;
+}
+
 void NewGameState::on_pushed()
 {
     std::unique_ptr<State> game_state(
@@ -59,6 +74,21 @@ void NewGameState::on_resume()
 // -----------------------------------------------------------------------------
 // Gain level state
 // -----------------------------------------------------------------------------
+GainLvlState::GainLvlState()
+{
+
+}
+
+GainLvlState::~GainLvlState()
+{
+
+}
+
+states::StateId GainLvlState::id()
+{
+    return states::StateId::NEWLEVEL_STATE;
+}
+
 void GainLvlState::on_start()
 {
     game::incr_clvl();
@@ -99,6 +129,16 @@ PickBgState::PickBgState() :
 
 }
 
+PickBgState::~PickBgState()
+{
+
+}
+
+states::StateId PickBgState::id()
+{
+    return states::StateId::BACKGROUND_STATE;
+}
+
 void PickBgState::on_start()
 {
     bgs_ = player_bon::pickable_bgs();
@@ -107,12 +147,6 @@ void PickBgState::on_start()
 
     // Let the browser start at Rogue, to recommend it as the default choice
     browser_.set_y((int)Bg::rogue);
-}
-
-void pop_states(const int number)
-{
-  for ( int i = 0; i < number; i++ )
-    states::pop();
 }
 
 void PickBgState::update()
@@ -147,7 +181,7 @@ void PickBgState::update()
 
     case MenuAction::esc:
     {
-      pop_states(4);
+      pop_until(states::StateId::MENU_STATE);
     }
     break;
 
@@ -241,6 +275,16 @@ PickTraitState::PickTraitState() :
 
 }
 
+PickTraitState::~PickTraitState()
+{
+
+}
+
+states::StateId PickTraitState::id()
+{
+    return states::StateId::TRAIT_STATE;
+}
+
 void PickTraitState::on_start()
 {
     const Bg player_bg = player_bon::bg();
@@ -291,7 +335,8 @@ void PickTraitState::update()
     {
     case MenuAction::esc:
     {
-      pop_states(3);
+      if (contains_state(states::StateId::NAME_STATE))
+          pop_until(states::StateId::MENU_STATE);
     }
     break;
 
@@ -543,6 +588,16 @@ EnterNameState::EnterNameState() :
 
 }
 
+EnterNameState::~EnterNameState()
+{
+
+}
+
+states::StateId EnterNameState::id()
+{
+    return states::StateId::NAME_STATE;
+}
+
 void EnterNameState::on_start()
 {
     const std::string default_name = config::default_player_name();
@@ -567,7 +622,7 @@ void EnterNameState::update()
 
     if (input.key == SDLK_ESCAPE)
     {
-      pop_states(2);
+      pop_until(states::StateId::MENU_STATE);
       return;
     }
 

--- a/src/create_character.cpp
+++ b/src/create_character.cpp
@@ -44,9 +44,9 @@ NewGameState::~NewGameState()
 
 }
 
-states::StateId NewGameState::id()
+StateId NewGameState::id()
 {
-    return states::StateId::NEWGAME_STATE;
+    return StateId::new_game;
 }
 
 void NewGameState::on_pushed()
@@ -84,9 +84,9 @@ GainLvlState::~GainLvlState()
 
 }
 
-states::StateId GainLvlState::id()
+StateId GainLvlState::id()
 {
-    return states::StateId::NEWLEVEL_STATE;
+    return StateId::new_level;
 }
 
 void GainLvlState::on_start()
@@ -134,9 +134,9 @@ PickBgState::~PickBgState()
 
 }
 
-states::StateId PickBgState::id()
+StateId PickBgState::id()
 {
-    return states::StateId::BACKGROUND_STATE;
+    return StateId::pick_background;
 }
 
 void PickBgState::on_start()
@@ -181,7 +181,7 @@ void PickBgState::update()
 
     case MenuAction::esc:
     {
-      pop_until(states::StateId::MENU_STATE);
+      states::pop_until(StateId::menu);
     }
     break;
 
@@ -280,9 +280,9 @@ PickTraitState::~PickTraitState()
 
 }
 
-states::StateId PickTraitState::id()
+StateId PickTraitState::id()
 {
-    return states::StateId::TRAIT_STATE;
+    return StateId::pick_trait;
 }
 
 void PickTraitState::on_start()
@@ -335,8 +335,8 @@ void PickTraitState::update()
     {
     case MenuAction::esc:
     {
-      if (contains_state(states::StateId::NAME_STATE))
-          pop_until(states::StateId::MENU_STATE);
+      if (states::contains_state(StateId::pick_name))
+          states::pop_until(StateId::menu);
     }
     break;
 
@@ -593,9 +593,9 @@ EnterNameState::~EnterNameState()
 
 }
 
-states::StateId EnterNameState::id()
+StateId EnterNameState::id()
 {
-    return states::StateId::NAME_STATE;
+    return StateId::pick_name;
 }
 
 void EnterNameState::on_start()
@@ -622,7 +622,7 @@ void EnterNameState::update()
 
     if (input.key == SDLK_ESCAPE)
     {
-      pop_until(states::StateId::MENU_STATE);
+      states::pop_until(StateId::menu);
       return;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1212,6 +1212,11 @@ const std::vector<HistoryEvent>& history()
 // -----------------------------------------------------------------------------
 // Game state
 // -----------------------------------------------------------------------------
+states::StateId GameState::id()
+{
+    return states::StateId::GAME_STATE;
+}
+
 void GameState::on_start()
 {
     // Some backgrounds and traits may have affected maximum hp and spi (either

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -59,8 +59,8 @@ void query_quit()
 {
     const auto quit_choices = std::vector<std::string>
     {
-        "yes",
-        "no"
+        "Yes",
+        "No"
     };
 
     const int quit_choice =

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1212,9 +1212,9 @@ const std::vector<HistoryEvent>& history()
 // -----------------------------------------------------------------------------
 // Game state
 // -----------------------------------------------------------------------------
-states::StateId GameState::id()
+StateId GameState::id()
 {
-    return states::StateId::GAME_STATE;
+    return StateId::game;
 }
 
 void GameState::on_start()

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -33,6 +33,8 @@ HighscoreEntry::HighscoreEntry(std::string entry_date_and_time,
     is_win_         (is_win_game),
     bg_             (player_bg) {}
 
+HighscoreEntry::~HighscoreEntry() {}
+
 int HighscoreEntry::score() const
 {
     const double dlvl_db = double(dlvl_);
@@ -214,6 +216,11 @@ namespace
 const int max_nr_lines_on_scr_ = screen_h - 3;
 
 } // namespace
+
+states::StateId BrowseHighscore::id()
+{
+    return states::StateId::HIGHSCORE_STATE;
+}
 
 void BrowseHighscore::on_start()
 {

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -217,9 +217,9 @@ const int max_nr_lines_on_scr_ = screen_h - 3;
 
 } // namespace
 
-states::StateId BrowseHighscore::id()
+StateId BrowseHighscore::id()
 {
-    return states::StateId::HIGHSCORE_STATE;
+    return StateId::highscore;
 }
 
 void BrowseHighscore::on_start()

--- a/src/inventory_handling.cpp
+++ b/src/inventory_handling.cpp
@@ -144,6 +144,11 @@ InvState::InvState() :
 
 }
 
+states::StateId InvState::id()
+{
+    return states::StateId::INV_STATE;
+}
+
 void InvState::draw_slot(const SlotId id,
                          const int y,
                          const char key,

--- a/src/inventory_handling.cpp
+++ b/src/inventory_handling.cpp
@@ -144,9 +144,9 @@ InvState::InvState() :
 
 }
 
-states::StateId InvState::id()
+StateId InvState::id()
 {
-    return states::StateId::INV_STATE;
+    return StateId::inventory;
 }
 
 void InvState::draw_slot(const SlotId id,

--- a/src/look.cpp
+++ b/src/look.cpp
@@ -29,6 +29,11 @@ const int max_nr_lines_on_scr_ = screen_h - 2;
 // -----------------------------------------------------------------------------
 // View actor description
 // -----------------------------------------------------------------------------
+states::StateId ViewActorDescr::id()
+{
+    return states::StateId::VIEWACTOR_STATE;
+}
+
 void ViewActorDescr::on_start()
 {
     // Fixed description.

--- a/src/look.cpp
+++ b/src/look.cpp
@@ -29,9 +29,9 @@ const int max_nr_lines_on_scr_ = screen_h - 2;
 // -----------------------------------------------------------------------------
 // View actor description
 // -----------------------------------------------------------------------------
-states::StateId ViewActorDescr::id()
+StateId ViewActorDescr::id()
 {
-    return states::StateId::VIEWACTOR_STATE;
+    return StateId::view_actor;
 }
 
 void ViewActorDescr::on_start()

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -222,6 +222,11 @@ MainMenuState::~MainMenuState()
 
 }
 
+states::StateId MainMenuState::id()
+{
+    return states::StateId::MENU_STATE;
+}
+
 void MainMenuState::draw()
 {
     P pos(map_w_half, 3);

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -222,9 +222,9 @@ MainMenuState::~MainMenuState()
 
 }
 
-states::StateId MainMenuState::id()
+StateId MainMenuState::id()
 {
-    return states::StateId::MENU_STATE;
+    return StateId::menu;
 }
 
 void MainMenuState::draw()

--- a/src/manual.cpp
+++ b/src/manual.cpp
@@ -15,6 +15,11 @@ const int max_nr_lines_on_scr_ = screen_h - 2;
 
 } // namespace
 
+states::StateId BrowseManual::id()
+{
+    return states::StateId::MANUAL_STATE;
+}
+
 void BrowseManual::on_start()
 {
     read_file();

--- a/src/manual.cpp
+++ b/src/manual.cpp
@@ -15,9 +15,9 @@ const int max_nr_lines_on_scr_ = screen_h - 2;
 
 } // namespace
 
-states::StateId BrowseManual::id()
+StateId BrowseManual::id()
 {
-    return states::StateId::MANUAL_STATE;
+    return StateId::manual;
 }
 
 void BrowseManual::on_start()

--- a/src/marker.cpp
+++ b/src/marker.cpp
@@ -21,9 +21,9 @@
 // -----------------------------------------------------------------------------
 // Marker state
 // -----------------------------------------------------------------------------
-states::StateId MarkerState::id()
+StateId MarkerState::id()
 {
-    return states::StateId::MARKER_STATE;
+    return StateId::marker;
 }
 
 void MarkerState::on_start()

--- a/src/marker.cpp
+++ b/src/marker.cpp
@@ -21,6 +21,11 @@
 // -----------------------------------------------------------------------------
 // Marker state
 // -----------------------------------------------------------------------------
+states::StateId MarkerState::id()
+{
+    return states::StateId::MARKER_STATE;
+}
+
 void MarkerState::on_start()
 {
     pos_ = map::player->pos;

--- a/src/msg_log.cpp
+++ b/src/msg_log.cpp
@@ -297,6 +297,11 @@ const std::vector< std::vector<Msg> > history()
 // -----------------------------------------------------------------------------
 // Message history state
 // -----------------------------------------------------------------------------
+states::StateId MsgHistoryState::id()
+{
+    return states::StateId::MESSAGE_STATE;
+}
+
 void MsgHistoryState::on_start()
 {
     history_ = msg_log::history();

--- a/src/msg_log.cpp
+++ b/src/msg_log.cpp
@@ -297,9 +297,9 @@ const std::vector< std::vector<Msg> > history()
 // -----------------------------------------------------------------------------
 // Message history state
 // -----------------------------------------------------------------------------
-states::StateId MsgHistoryState::id()
+StateId MsgHistoryState::id()
 {
-    return states::StateId::MESSAGE_STATE;
+    return StateId::message;
 }
 
 void MsgHistoryState::on_start()

--- a/src/postmortem.cpp
+++ b/src/postmortem.cpp
@@ -38,9 +38,9 @@ PostmortemMenu::PostmortemMenu() :
     browser_.reset(7);
 }
 
-states::StateId PostmortemMenu::id()
+StateId PostmortemMenu::id()
 {
-    return states::StateId::POSTMENU_STATE;
+    return StateId::postmortem_menu;
 }
 
 void PostmortemMenu::on_start()
@@ -493,9 +493,9 @@ void PostmortemMenu::update()
 // -----------------------------------------------------------------------------
 // Postmortem info
 // -----------------------------------------------------------------------------
-states::StateId PostmortemInfo::id()
+StateId PostmortemInfo::id()
 {
-    return states::StateId::POSTINFO_STATE;
+    return StateId::postmortem_info;
 }
 
 void PostmortemInfo::draw()

--- a/src/postmortem.cpp
+++ b/src/postmortem.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <string>
 
+#include "audio.hpp"
 #include "init.hpp"
 #include "io.hpp"
 #include "actor_player.hpp"
@@ -403,6 +404,8 @@ void PostmortemMenu::update()
             std::unique_ptr<State> new_game_state(new NewGameState);
 
             states::push(std::move(new_game_state));
+
+            audio::fade_out_music();
 
             return;
         }

--- a/src/postmortem.cpp
+++ b/src/postmortem.cpp
@@ -38,6 +38,11 @@ PostmortemMenu::PostmortemMenu() :
     browser_.reset(7);
 }
 
+states::StateId PostmortemMenu::id()
+{
+    return states::StateId::POSTMENU_STATE;
+}
+
 void PostmortemMenu::on_start()
 {
     info_lines_.clear();
@@ -488,6 +493,11 @@ void PostmortemMenu::update()
 // -----------------------------------------------------------------------------
 // Postmortem info
 // -----------------------------------------------------------------------------
+states::StateId PostmortemInfo::id()
+{
+    return states::StateId::POSTINFO_STATE;
+}
+
 void PostmortemInfo::draw()
 {
     io::clear_screen();

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -147,6 +147,11 @@ Spell* mk_spell_from_id(const SpellId spell_id)
 
 } // spell_handling
 
+states::StateId BrowseSpell::id()
+{
+    return states::StateId::BROWSESPELLS_STATE;
+}
+
 Range Spell::spi_cost(Actor* const caster) const
 {
     int cost_max = max_spi_cost();

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -147,9 +147,9 @@ Spell* mk_spell_from_id(const SpellId spell_id)
 
 } // spell_handling
 
-states::StateId BrowseSpell::id()
+StateId BrowseSpell::id()
 {
-    return states::StateId::BROWSESPELLS_STATE;
+    return StateId::browse_spells;
 }
 
 Range Spell::spi_cost(Actor* const caster) const

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -148,23 +148,7 @@ void pop_all()
     TRACE_FUNC_END;
 }
 
-bool check_states(const states::StateId state_given, const states::StateId state_to_check)
-{                               //This is from the vector, and this is to check for.
-    if (state_to_check == states::StateId::DEFAULT_STATE)
-        return false;
-
-    //^If it should pop 'till default state, then stop without popping a single state.
-
-    if (state_given == state_to_check)
-        return false;
-
-    //^If the states are the same, just stop.
-    
-    return true;
-    //^Returning true as default.
-}
-
-bool contains_state(const states::StateId state)
+bool contains_state(const StateId state)
 {
     for( auto&& p : states_ ) {
         if(p->id() == state)
@@ -174,12 +158,12 @@ bool contains_state(const states::StateId state)
     return false;
 }
 
-void pop_until(const states::StateId state)
+void pop_until(const StateId state)
 {
     if (is_empty())
         return;
 
-    if (check_states(states_.back().get()->id(), state))
+    if (states_.back().get()->id() != state)
     {
         pop();
         pop_until(state);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -148,6 +148,44 @@ void pop_all()
     TRACE_FUNC_END;
 }
 
+bool check_states(const states::StateId state_given, const states::StateId state_to_check)
+{                               //This is from the vector, and this is to check for.
+    if (state_to_check == states::StateId::DEFAULT_STATE)
+        return false;
+
+    //^If it should pop 'till default state, then stop without popping a single state.
+
+    if (state_given == state_to_check)
+        return false;
+
+    //^If the states are the same, just stop.
+    
+    return true;
+    //^Returning true as default.
+}
+
+bool contains_state(const states::StateId state)
+{
+    for( auto&& p : states_ ) {
+        if(p->id() == state)
+            return true;
+    }
+
+    return false;
+}
+
+void pop_until(const states::StateId state)
+{
+    if (is_empty())
+        return;
+
+    if (check_states(states_.back().get()->id(), state))
+    {
+        pop();
+        pop_until(state);
+    }
+}
+
 bool is_empty()
 {
     return states_.empty();


### PR DESCRIPTION
Hello again,

I deleted all the bad things from the commit you didn't accept (everything), and replaced it with a long workaround:

- I added IDs for each State, put in an enum class, overrode that for each State child.
- Changed some constructor implementations - by that I mean I moved the definition in a corresponding file and not in the header, because some classes had them like that, some didn't, it didn't matter and it was inconsistent.
- Added some "smart" popping methods in states.cpp, which work based on the State children ids.

I hope I respected your style. I added comments only where I saw necessary.
I tested this in both scenarios - when leveling up in a game and when actually starting a new game - and it apparently works.

I hope this is alright - I was quite a bit too far into doing this that I realized I needed to differentiate between the two ways a user could get to the trait screen, which you specified in the other PR.

Lastly, a way to get in contact with you, through IRC or something would be pretty nice, I suppose; at times I wanted to ask if X thing was something you'd accept or not.