### PR TITLE
Better mingw32 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ set_target_properties(ia-debug  PROPERTIES OUTPUT_NAME ia-debug)
 
 # GNU gcc and Clang specific compiler flags
 if(CMAKE_COMPILER_IS_GNUCXX OR(CMAKE_C_COMPILER_ID MATCHES "Clang") OR(CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-  
+
   set(COMMON_COMPILE_FLAGS
     -std=c++14
     -fno-rtti
@@ -302,6 +302,9 @@ if(WIN32)
   if(CMAKE_COMPILER_IS_GNUCXX OR(CMAKE_C_COMPILER_ID MATCHES "Clang") OR(CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
     target_link_libraries(ia -mwindows)
   endif()
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    target_link_libraries(ia -static-libgcc -static-libstdc++)
+  endif()
 endif()
 
 # Copy all resource files to the build directory.
@@ -313,24 +316,26 @@ file(COPY res DESTINATION .)
 # ------------------------------------------------------------------------------
 if(WIN32)
 
-    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
-        message(STATUS "Assuming 32 bit architecture")
+    if (NOT DEFINED ARCH)
 
-        set(ARCH 32bit)
+        if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+            message(STATUS "Assuming 32 bit architecture")
+            set(ARCH 32bit)
+        elseif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+            message(STATUS "Assuming 64 bit architecture")
+            set(ARCH 64bit)
+        endif()
 
-    elseif("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-        message(STATUS "Assuming 64 bit architecture")
+    endif()
 
-        set(ARCH 64bit)
-
-    else()
+    if (NOT DEFINED ARCH OR ((NOT "${ARCH}" EQUAL "32bit") AND (NOT "${ARCH}" EQUAL "64bit")))
         message(FATAL_ERROR "Unknown architecture")
     endif()
 
     set(SDL_BASE_DIR ${CMAKE_SOURCE_DIR}/SDL)
 
     if(MSVC)
-    
+
         if("${ARCH}" EQUAL "32bit")
             set(SDL_ARCH_DIR x86)
         else()

--- a/Toolchain-cross-mingw32.txt
+++ b/Toolchain-cross-mingw32.txt
@@ -1,0 +1,14 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+if("${ARCH}" EQUAL "32bit")
+    set(SDL_ARCH_DIR i686-w64-mingw32)
+    set(CMAKE_C_COMPILER i686-w64-mingw32-gcc)
+    set(CMAKE_CXX_COMPILER i686-w64-mingw32-g++)
+    set(CMAKE_RC_COMPILER i686-w64-mingw32-windres)
+else()
+    set(SDL_ARCH_DIR x86_64-w64-mingw32)
+    set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+    set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+    set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+endif()


### PR DESCRIPTION
One commit to add a toolchain file and make some modifications to the CMake listfile to better support mingw32. I was able to crosscompile from Linux to Windows for both 32-bit and 64-bit ia.exe versions, and both binaries worked in Wine and in a Win 10 VM.

If linux mingw32 support is good, it easier to set up a server to automatically build windows+linux packages that gets run e.g. hourly or daily.

Example cmake command for setting up a 32-bit windows build from a 64-bit linux machine:

```
cmake -DWIN32=TRUE -DMSVC=FALSE -DARCH=32bit \
      -DCMAKE_TOOLCHAIN_FILE=../Toolchain-cross-mingw32.txt ..
```
