### PR TITLE
Add Molotov Coctail explosion warning

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1676,6 +1676,16 @@ void Molotov::on_std_turn_player_hold_ignited()
 {
     --fuse_turns_;
 
+    if (fuse_turns_ == 2)
+    {
+        msg_log::add("The Molotov Coctail will soon explode.");
+    }
+
+    if (fuse_turns_ == 1)
+    {
+        msg_log::add("The Molotov Coctail is about to explode!");
+    }
+
     if (fuse_turns_ <= 0)
     {
         msg_log::add("The Molotov Cocktail explodes in my hand!");


### PR DESCRIPTION
Added warnings on the two turns before a Molotov Cocktail explodes in the character's hands.